### PR TITLE
Intercept MotionEvent when performDismiss() is called

### DIFF
--- a/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
+++ b/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
@@ -170,6 +170,7 @@ public class SwipeDismissTouchListener implements View.OnTouchListener {
                                     performDismiss();
                                 }
                             });
+                    return true;
                 } else {
                     // cancel
                     mView.animate()


### PR DESCRIPTION
When we have decided to dismiss the view, we should return true in onInterceptTouchEvent() to intercept the MotionEvent and stop the event being passed to the view. 

Without this fix when a view is dismissed / hidden quickly it's possible to trigger the onClickListener and click the hidden view.
