### PR TITLE
Fix failure to reset layout params to correct setting after dismiss is c...

### DIFF
--- a/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
+++ b/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
@@ -252,6 +252,8 @@ public class SwipeDismissTouchListener implements View.OnTouchListener {
 
         final ViewGroup.LayoutParams lp = mView.getLayoutParams();
         final int originalHeight = mView.getHeight();
+        final int lpHeight = lp.height;
+
 
         ValueAnimator animator = ValueAnimator.ofInt(originalHeight, 1).setDuration(mAnimationTime);
 
@@ -262,7 +264,7 @@ public class SwipeDismissTouchListener implements View.OnTouchListener {
                 // Reset view presentation
                 mView.setAlpha(1f);
                 mView.setTranslationX(0);
-                lp.height = originalHeight;
+                lp.height = lpHeight;
                 mView.setLayoutParams(lp);
             }
         });


### PR DESCRIPTION
...omplete.

Bug: If layoutParams of dismissed view are WRAP_CONTENT, then this setting is overwritten with the original  getHeight() of the View instead of returning to WRAP_CONTENT.
This was breaking our list view cell's when they were being reused by the list view. They were no longer dynamically resizing but were instead locked to 'originalHeight' forever after.
