### PR TITLE
Fixing wrong view get ACTION_CANCEL event

### DIFF
--- a/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
+++ b/src/com/example/android/swipedismiss/SwipeDismissTouchListener.java
@@ -220,14 +220,14 @@ public class SwipeDismissTouchListener implements View.OnTouchListener {
                 if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2) {
                     mSwiping = true;
                     mSwipingSlop = (deltaX > 0 ? mSlop : -mSlop);
-                    mView.getParent().requestDisallowInterceptTouchEvent(true);
+                    view.getParent().requestDisallowInterceptTouchEvent(true);
 
                     // Cancel listview's touch
                     MotionEvent cancelEvent = MotionEvent.obtain(motionEvent);
                     cancelEvent.setAction(MotionEvent.ACTION_CANCEL |
                             (motionEvent.getActionIndex() <<
                                     MotionEvent.ACTION_POINTER_INDEX_SHIFT));
-                    mView.onTouchEvent(cancelEvent);
+                    view.onTouchEvent(cancelEvent);
                     cancelEvent.recycle();
                 }
 


### PR DESCRIPTION
When the same listener is attached to the root view and a child view (like a EditText), the ACTION_CANCEL should be sent to the view receiving the events (like in the above case, EditText should not show the "Paste" option).
